### PR TITLE
ICU-20568 Fix "1 foot 12 inches" behaviour

### DIFF
--- a/icu4c/source/i18n/number_rounding.cpp
+++ b/icu4c/source/i18n/number_rounding.cpp
@@ -24,47 +24,6 @@ using namespace icu::number::impl;
 using double_conversion::DoubleToStringConverter;
 using icu::StringSegment;
 
-// Original full body of blueprint_helpers::parseIncrementOption (FIXME delete):
-//
-// // Most blueprint_helpers live in number_skeletons.cpp. This one is in
-// // number_rounding.cpp for dependency reasons.
-// void blueprint_helpers::parseIncrementOption(const StringSegment &segment, MacroProps &macros,
-//                                              UErrorCode &status) {
-//     // Need to do char <-> UChar conversion...
-//     U_ASSERT(U_SUCCESS(status));
-//     CharString buffer;
-//     SKELETON_UCHAR_TO_CHAR(buffer, segment.toTempUnicodeString(), 0, segment.length(), status);
-
-//     // Utilize DecimalQuantity/decNumber to parse this for us.
-//     DecimalQuantity dq;
-//     UErrorCode localStatus = U_ZERO_ERROR;
-//     dq.setToDecNumber({buffer.data(), buffer.length()}, localStatus);
-//     if (U_FAILURE(localStatus)) {
-//         // throw new SkeletonSyntaxException("Invalid rounding increment", segment, e);
-//         status = U_NUMBER_SKELETON_SYNTAX_ERROR;
-//         return;
-//     }
-//     double increment = dq.toDouble();
-
-//     // We also need to figure out how many digits. Do a brute force string operation.
-//     int decimalOffset = 0;
-//     while (decimalOffset < segment.length() && segment.charAt(decimalOffset) != '.') {
-//         decimalOffset++;
-//     }
-//     if (decimalOffset == segment.length()) {
-//         macros.precision = Precision::increment(increment);
-//     } else {
-//         int32_t fractionLength = segment.length() - decimalOffset - 1;
-//         macros.precision = Precision::increment(increment).withMinFraction(fractionLength);
-//     }
-// }
-
-// Modified version of blueprint_helpers::parseIncrementOption to remove
-// MacroProps, thereby avoiding need for symbols
-// number::impl::SymbolsWrapper::~SymbolsWrapper(),
-// number::impl::Usage::~Usage(), number::Scale::~Scale() in the dependencies.
-// (Could this trickiness alternatively be improved by moving destructors into
-// header files?)
 void number::impl::parseIncrementOption(const StringSegment &segment, Precision &precision,
                                         UErrorCode &status) {
     // Need to do char <-> UChar conversion...

--- a/icu4c/source/i18n/number_rounding.cpp
+++ b/icu4c/source/i18n/number_rounding.cpp
@@ -24,10 +24,49 @@ using namespace icu::number::impl;
 using double_conversion::DoubleToStringConverter;
 using icu::StringSegment;
 
-// Most blueprint_helpers live in number_skeletons.cpp. This one is in
-// number_rounding.cpp for dependency reasons.
-void blueprint_helpers::parseIncrementOption(const StringSegment &segment, MacroProps &macros,
-                                             UErrorCode &status) {
+// Original full body of blueprint_helpers::parseIncrementOption (FIXME delete):
+//
+// // Most blueprint_helpers live in number_skeletons.cpp. This one is in
+// // number_rounding.cpp for dependency reasons.
+// void blueprint_helpers::parseIncrementOption(const StringSegment &segment, MacroProps &macros,
+//                                              UErrorCode &status) {
+//     // Need to do char <-> UChar conversion...
+//     U_ASSERT(U_SUCCESS(status));
+//     CharString buffer;
+//     SKELETON_UCHAR_TO_CHAR(buffer, segment.toTempUnicodeString(), 0, segment.length(), status);
+
+//     // Utilize DecimalQuantity/decNumber to parse this for us.
+//     DecimalQuantity dq;
+//     UErrorCode localStatus = U_ZERO_ERROR;
+//     dq.setToDecNumber({buffer.data(), buffer.length()}, localStatus);
+//     if (U_FAILURE(localStatus)) {
+//         // throw new SkeletonSyntaxException("Invalid rounding increment", segment, e);
+//         status = U_NUMBER_SKELETON_SYNTAX_ERROR;
+//         return;
+//     }
+//     double increment = dq.toDouble();
+
+//     // We also need to figure out how many digits. Do a brute force string operation.
+//     int decimalOffset = 0;
+//     while (decimalOffset < segment.length() && segment.charAt(decimalOffset) != '.') {
+//         decimalOffset++;
+//     }
+//     if (decimalOffset == segment.length()) {
+//         macros.precision = Precision::increment(increment);
+//     } else {
+//         int32_t fractionLength = segment.length() - decimalOffset - 1;
+//         macros.precision = Precision::increment(increment).withMinFraction(fractionLength);
+//     }
+// }
+
+// Modified version of blueprint_helpers::parseIncrementOption to remove
+// MacroProps, thereby avoiding need for symbols
+// number::impl::SymbolsWrapper::~SymbolsWrapper(),
+// number::impl::Usage::~Usage(), number::Scale::~Scale() in the dependencies.
+// (Could this trickiness alternatively be improved by moving destructors into
+// header files?)
+void number::impl::parseIncrementOption(const StringSegment &segment, Precision &precision,
+                                        UErrorCode &status) {
     // Need to do char <-> UChar conversion...
     U_ASSERT(U_SUCCESS(status));
     CharString buffer;
@@ -50,10 +89,10 @@ void blueprint_helpers::parseIncrementOption(const StringSegment &segment, Macro
         decimalOffset++;
     }
     if (decimalOffset == segment.length()) {
-        macros.precision = Precision::increment(increment);
+        precision = Precision::increment(increment);
     } else {
         int32_t fractionLength = segment.length() - decimalOffset - 1;
-        macros.precision = Precision::increment(increment).withMinFraction(fractionLength);
+        precision = Precision::increment(increment).withMinFraction(fractionLength);
     }
 }
 

--- a/icu4c/source/i18n/number_roundingutils.h
+++ b/icu4c/source/i18n/number_roundingutils.h
@@ -199,14 +199,14 @@ class RoundingImpl {
     friend class UnitConversionHandler;
 };
 
-/* We want to be able to parse Precision-related skeleton strings without
- * needing to pull in the .o files required for instantiating MacroProps
- * instances.
- * - blueprint_helpers::parseIncrementOption uses MacroProps.
- * - UnitsRouter needs to parse skeletons
+/**
+ * Parses Precision-related skeleton strings without knowledge of MacroProps
+ * - see blueprint_helpers::parseIncrementOption().
+ *
+ * Referencing MacroProps means needing to pull in the .o files that have the
+ * destructors for the SymbolsWrapper, Usage, and Scale classes.
  */
-void parseIncrementOption(const StringSegment &segment, Precision &precision,
-                                    UErrorCode &status);
+void parseIncrementOption(const StringSegment &segment, Precision &precision, UErrorCode &status);
 
 } // namespace impl
 } // namespace number

--- a/icu4c/source/i18n/number_roundingutils.h
+++ b/icu4c/source/i18n/number_roundingutils.h
@@ -8,6 +8,7 @@
 #define __NUMBER_ROUNDINGUTILS_H__
 
 #include "number_types.h"
+#include "string_segment.h"
 
 U_NAMESPACE_BEGIN
 namespace number {
@@ -198,6 +199,14 @@ class RoundingImpl {
     friend class UnitConversionHandler;
 };
 
+/* We want to be able to parse Precision-related skeleton strings without
+ * needing to pull in the .o files required for instantiating MacroProps
+ * instances.
+ * - blueprint_helpers::parseIncrementOption uses MacroProps.
+ * - UnitsRouter needs to parse skeletons
+ */
+void parseIncrementOption(const StringSegment &segment, Precision &precision,
+                                    UErrorCode &status);
 
 } // namespace impl
 } // namespace number

--- a/icu4c/source/i18n/number_roundingutils.h
+++ b/icu4c/source/i18n/number_roundingutils.h
@@ -193,7 +193,7 @@ class RoundingImpl {
     bool fPassThrough = true;  // default value
 
     // Permits access to fPrecision.
-    friend class UsagePrefsHandler;
+    friend class units::UnitsRouter;
 
     // Permits access to fPrecision.
     friend class UnitConversionHandler;

--- a/icu4c/source/i18n/number_skeletons.cpp
+++ b/icu4c/source/i18n/number_skeletons.cpp
@@ -10,6 +10,7 @@
 #define UNISTR_FROM_STRING_EXPLICIT
 
 #include "number_decnum.h"
+#include "number_roundingutils.h"
 #include "number_skeletons.h"
 #include "umutex.h"
 #include "ucln_in.h"
@@ -1333,8 +1334,10 @@ bool blueprint_helpers::parseFracSigOption(const StringSegment& segment, MacroPr
     return true;
 }
 
-// blueprint_helpers::parseIncrementOption lives in number_rounding.cpp for
-// dependencies reasons.
+void blueprint_helpers::parseIncrementOption(const StringSegment &segment, MacroProps &macros,
+                                             UErrorCode &status) {
+    number::impl::parseIncrementOption(segment, macros.precision, status);
+}
 
 void blueprint_helpers::generateIncrementOption(double increment, int32_t trailingZeros, UnicodeString& sb,
                                                 UErrorCode&) {

--- a/icu4c/source/i18n/number_usageprefs.cpp
+++ b/icu4c/source/i18n/number_usageprefs.cpp
@@ -163,6 +163,7 @@ void UsagePrefsHandler::processQuantity(DecimalQuantity &quantity, MicroProps &m
     }
 }
 
+// TODO: deduplicate this code, number_usageprefs.cpp & units_router.cpp
 Precision UsagePrefsHandler::parseSkeletonToPrecision(icu::UnicodeString precisionSkeleton,
                                                       UErrorCode status) {
     if (U_FAILURE(status)) {
@@ -178,9 +179,9 @@ Precision UsagePrefsHandler::parseSkeletonToPrecision(icu::UnicodeString precisi
     U_ASSERT(precisionSkeleton[kSkelPrefixLen - 1] == u'/');
     StringSegment segment(precisionSkeleton, false);
     segment.adjustOffset(kSkelPrefixLen);
-    MacroProps macros;
-    blueprint_helpers::parseIncrementOption(segment, macros, status);
-    return macros.precision;
+    Precision result;
+    number::impl::parseIncrementOption(segment, result, status);
+    return result;
 }
 
 UnitConversionHandler::UnitConversionHandler(const MeasureUnit &unit, const MicroPropsGenerator *parent,

--- a/icu4c/source/i18n/number_usageprefs.cpp
+++ b/icu4c/source/i18n/number_usageprefs.cpp
@@ -151,27 +151,6 @@ void UsagePrefsHandler::processQuantity(DecimalQuantity &quantity, MicroProps &m
     mixedMeasuresToMicros(routedUnits, &quantity, &micros, status);
 }
 
-// TODO: deduplicate this code, number_usageprefs.cpp & units_router.cpp
-Precision UsagePrefsHandler::parseSkeletonToPrecision(icu::UnicodeString precisionSkeleton,
-                                                      UErrorCode status) {
-    if (U_FAILURE(status)) {
-        // As a member of UsagePrefsHandler, which is a friend of Precision, we
-        // get access to the default constructor.
-        return {};
-    }
-    constexpr int32_t kSkelPrefixLen = 20;
-    if (!precisionSkeleton.startsWith(UNICODE_STRING_SIMPLE("precision-increment/"))) {
-        status = U_INVALID_FORMAT_ERROR;
-        return {};
-    }
-    U_ASSERT(precisionSkeleton[kSkelPrefixLen - 1] == u'/');
-    StringSegment segment(precisionSkeleton, false);
-    segment.adjustOffset(kSkelPrefixLen);
-    Precision result;
-    number::impl::parseIncrementOption(segment, result, status);
-    return result;
-}
-
 UnitConversionHandler::UnitConversionHandler(const MeasureUnit &unit, const MicroPropsGenerator *parent,
                                              UErrorCode &status)
     : fOutputUnit(unit), fParent(parent) {

--- a/icu4c/source/i18n/number_usageprefs.cpp
+++ b/icu4c/source/i18n/number_usageprefs.cpp
@@ -138,7 +138,7 @@ void UsagePrefsHandler::processQuantity(DecimalQuantity &quantity, MicroProps &m
     }
 
     quantity.roundToInfinity(); // Enables toDouble
-    const auto routed = fUnitsRouter.route(quantity.toDouble(), &micros.rounder, status);
+    const units::RouteResult routed = fUnitsRouter.route(quantity.toDouble(), &micros.rounder, status);
     if (U_FAILURE(status)) {
         return;
     }
@@ -149,18 +149,6 @@ void UsagePrefsHandler::processQuantity(DecimalQuantity &quantity, MicroProps &m
     }
 
     mixedMeasuresToMicros(routedUnits, &quantity, &micros, status);
-
-    UnicodeString precisionSkeleton = routed.precision;
-    if (micros.rounder.fPrecision.isBogus()) {
-        if (precisionSkeleton.length() > 0) {
-            micros.rounder.fPrecision = parseSkeletonToPrecision(precisionSkeleton, status);
-        } else {
-            // We use the same rounding mode as COMPACT notation: known to be a
-            // human-friendly rounding mode: integers, but add a decimal digit
-            // as needed to ensure we have at least 2 significant digits.
-            micros.rounder.fPrecision = Precision::integer().withMinDigits(2);
-        }
-    }
 }
 
 // TODO: deduplicate this code, number_usageprefs.cpp & units_router.cpp
@@ -216,19 +204,14 @@ void UnitConversionHandler::processQuantity(DecimalQuantity &quantity, MicroProp
         return;
     }
     quantity.roundToInfinity(); // Enables toDouble
-    MaybeStackVector<Measure> measures = fUnitConverter->convert(quantity.toDouble(), &micros.rounder, status);
+    MaybeStackVector<Measure> measures =
+        fUnitConverter->convert(quantity.toDouble(), &micros.rounder, status);
     micros.outputUnit = fOutputUnit;
     if (U_FAILURE(status)) {
         return;
     }
 
     mixedMeasuresToMicros(measures, &quantity, &micros, status);
-
-    // TODO: add tests to explore behaviour that may suggest a more
-    // human-centric default rounder?
-    // if (micros.rounder.fPrecision.isBogus()) {
-    //     micros.rounder.fPrecision = Precision::integer().withMinDigits(2);
-    // }
 }
 
 #endif /* #if !UCONFIG_NO_FORMATTING */

--- a/icu4c/source/i18n/number_usageprefs.cpp
+++ b/icu4c/source/i18n/number_usageprefs.cpp
@@ -138,7 +138,7 @@ void UsagePrefsHandler::processQuantity(DecimalQuantity &quantity, MicroProps &m
     }
 
     quantity.roundToInfinity(); // Enables toDouble
-    const auto routed = fUnitsRouter.route(quantity.toDouble(), status);
+    const auto routed = fUnitsRouter.route(quantity.toDouble(), &micros.rounder, status);
     if (U_FAILURE(status)) {
         return;
     }
@@ -216,7 +216,7 @@ void UnitConversionHandler::processQuantity(DecimalQuantity &quantity, MicroProp
         return;
     }
     quantity.roundToInfinity(); // Enables toDouble
-    MaybeStackVector<Measure> measures = fUnitConverter->convert(quantity.toDouble(), status);
+    MaybeStackVector<Measure> measures = fUnitConverter->convert(quantity.toDouble(), &micros.rounder, status);
     micros.outputUnit = fOutputUnit;
     if (U_FAILURE(status)) {
         return;

--- a/icu4c/source/i18n/number_usageprefs.h
+++ b/icu4c/source/i18n/number_usageprefs.h
@@ -60,8 +60,6 @@ class U_I18N_API UsagePrefsHandler : public MicroPropsGenerator, public UMemory 
   private:
     UnitsRouter fUnitsRouter;
     const MicroPropsGenerator *fParent;
-
-    static Precision parseSkeletonToPrecision(icu::UnicodeString precisionSkeleton, UErrorCode status);
 };
 
 } // namespace impl

--- a/icu4c/source/i18n/unicode/measure.h
+++ b/icu4c/source/i18n/unicode/measure.h
@@ -24,7 +24,6 @@
  
 #if !UCONFIG_NO_FORMATTING
 
-#include "uassert.h"
 #include "unicode/fmtable.h"
 
 U_NAMESPACE_BEGIN
@@ -155,7 +154,6 @@ inline const Formattable& Measure::getNumber() const {
 }
 
 inline const MeasureUnit& Measure::getUnit() const {
-    U_ASSERT(unit != nullptr);
     return *unit;
 }
 

--- a/icu4c/source/i18n/unicode/measure.h
+++ b/icu4c/source/i18n/unicode/measure.h
@@ -24,6 +24,7 @@
  
 #if !UCONFIG_NO_FORMATTING
 
+#include "uassert.h"
 #include "unicode/fmtable.h"
 
 U_NAMESPACE_BEGIN
@@ -154,6 +155,7 @@ inline const Formattable& Measure::getNumber() const {
 }
 
 inline const MeasureUnit& Measure::getUnit() const {
+    U_ASSERT(unit != nullptr);
     return *unit;
 }
 

--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -99,6 +99,13 @@ class MultiplierParseHandler;
 }
 }
 
+namespace units {
+
+// Forward declarations:
+class UnitsRouter;
+
+} // namespace units
+
 namespace number {  // icu::number
 
 // Forward declarations:
@@ -765,6 +772,7 @@ class U_I18N_API Precision : public UMemory {
 
     // To allow access to isBogus and the default (bogus) constructor:
     friend class impl::UsagePrefsHandler;
+    friend class units::UnitsRouter;
 };
 
 /**

--- a/icu4c/source/i18n/unicode/numberformatter.h
+++ b/icu4c/source/i18n/unicode/numberformatter.h
@@ -165,7 +165,6 @@ struct UFormattedNumberImpl;
 class MutablePatternModifier;
 class ImmutablePatternModifier;
 struct DecimalFormatWarehouse;
-class UsagePrefsHandler;
 
 /**
  * Used for NumberRangeFormatter and implemented in numrange_fluent.cpp.
@@ -771,7 +770,6 @@ class U_I18N_API Precision : public UMemory {
     friend class impl::GeneratorHelpers;
 
     // To allow access to isBogus and the default (bogus) constructor:
-    friend class impl::UsagePrefsHandler;
     friend class units::UnitsRouter;
 };
 

--- a/icu4c/source/i18n/units_complexconverter.h
+++ b/icu4c/source/i18n/units_complexconverter.h
@@ -74,10 +74,12 @@ class U_I18N_API ComplexUnitsConverter : public UMemory {
     //         NOTE:
     //           the smallest element is the only element that could have fractional values. And all
     //           other elements are floored to the nearest integer
+    MaybeStackVector<Measure>
+    convert(double quantity, icu::number::impl::RoundingImpl *rounder, UErrorCode &status) const;
+
     MaybeStackVector<Measure> convert(double quantity, UErrorCode &status) const {
-      return convert(quantity, nullptr, status);
+        return convert(quantity, nullptr, status);
     }
-    MaybeStackVector<Measure> convert(double quantity, icu::number::impl::RoundingImpl *rounder, UErrorCode &status) const;
 
   private:
     MaybeStackVector<UnitConverter> unitConverters_;

--- a/icu4c/source/i18n/units_complexconverter.h
+++ b/icu4c/source/i18n/units_complexconverter.h
@@ -9,6 +9,7 @@
 
 #include "cmemory.h"
 #include "measunit_impl.h"
+#include "number_roundingutils.h"
 #include "unicode/errorcode.h"
 #include "unicode/measure.h"
 #include "units_converter.h"
@@ -73,7 +74,10 @@ class U_I18N_API ComplexUnitsConverter : public UMemory {
     //         NOTE:
     //           the smallest element is the only element that could have fractional values. And all
     //           other elements are floored to the nearest integer
-    MaybeStackVector<Measure> convert(double quantity, UErrorCode &status) const;
+    MaybeStackVector<Measure> convert(double quantity, UErrorCode &status) const {
+      return convert(quantity, nullptr, status);
+    }
+    MaybeStackVector<Measure> convert(double quantity, icu::number::impl::RoundingImpl *rounder, UErrorCode &status) const;
 
   private:
     MaybeStackVector<UnitConverter> unitConverters_;

--- a/icu4c/source/i18n/units_converter.cpp
+++ b/icu4c/source/i18n/units_converter.cpp
@@ -510,12 +510,31 @@ double UnitConverter::convert(double inputValue) const {
 
     result -= conversionRate_.targetOffset; // Set the result to its index.
 
-    if (result == 0)
+    if (result == 0) {
+        // TODO: test the resulting behaviour when we have 0.0 and reciprocal.
+        // (Theoretical result: infinity.)
         return 0.0; // If the result is zero, it does not matter if the conversion are reciprocal or not.
+    }
     if (conversionRate_.reciprocal) {
         result = 1.0 / result;
     }
 
+    return result;
+}
+
+double UnitConverter::convertInverse(double inputValue) const {
+    double result = inputValue;
+    if (result == 0) {
+        // TODO: test the resulting behaviour when we have 0.0 and reciprocal.
+        // (Theoretical result: infinity.) For now, we follow convert()'s shortcut:
+        return 0.0;
+    }
+    if (conversionRate_.reciprocal) {
+        result = 1.0 / result;
+    }
+    result += conversionRate_.targetOffset;
+    result *= conversionRate_.factorDen / conversionRate_.factorNum;
+    result -= conversionRate_.sourceOffset;
     return result;
 }
 

--- a/icu4c/source/i18n/units_converter.h
+++ b/icu4c/source/i18n/units_converter.h
@@ -144,13 +144,22 @@ class U_I18N_API UnitConverter : public UMemory {
                   const ConversionRates &ratesInfo, UErrorCode &status);
 
     /**
-     * Convert a value in the source unit to another value in the target unit.
+     * Convert a measurement expressed in the source unit to a measurement
+     * expressed in the target unit.
      *
-     * @param input_value the value that needs to be converted.
-     * @param output_value the value that holds the result of the conversion.
-     * @param status
+     * @param inputValue the value to be converted.
+     * @return the converted value.
      */
     double convert(double inputValue) const;
+
+    /**
+     * The inverse of convert(): convert a measurement expressed in the target
+     * unit to a measurement expressed in the source unit.
+     *
+     * @param inputValue the value to be converted.
+     * @return the converted value.
+     */
+    double convertInverse(double inputValue) const;
 
   private:
     ConversionRate conversionRate_;

--- a/icu4c/source/i18n/units_router.cpp
+++ b/icu4c/source/i18n/units_router.cpp
@@ -117,7 +117,6 @@ RouteResult UnitsRouter::route(double quantity, icu::number::impl::RoundingImpl 
     }
 
     return RouteResult(converterPreference->converter.convert(quantity, rounder, status),
-                       converterPreference->precision,
                        converterPreference->targetUnit.copy(status));
 }
 

--- a/icu4c/source/i18n/units_router.cpp
+++ b/icu4c/source/i18n/units_router.cpp
@@ -22,7 +22,6 @@ namespace units {
 using number::Precision;
 using number::impl::parseIncrementOption;
 
-// TODO: deduplicate this code, number_usageprefs.cpp & units_router.cpp
 Precision UnitsRouter::parseSkeletonToPrecision(icu::UnicodeString precisionSkeleton,
                                                 UErrorCode &status) {
     if (U_FAILURE(status)) {

--- a/icu4c/source/i18n/units_router.cpp
+++ b/icu4c/source/i18n/units_router.cpp
@@ -100,12 +100,12 @@ UnitsRouter::UnitsRouter(MeasureUnit inputUnit, StringPiece region, StringPiece 
     }
 }
 
-RouteResult UnitsRouter::route(double quantity, UErrorCode &status) const {
+RouteResult UnitsRouter::route(double quantity, icu::number::impl::RoundingImpl *rounder, UErrorCode &status) const {
     for (int i = 0, n = converterPreferences_.length(); i < n; i++) {
         const auto &converterPreference = *converterPreferences_[i];
         if (converterPreference.converter.greaterThanOrEqual(quantity * (1 + DBL_EPSILON),
                                                              converterPreference.limit)) {
-            return RouteResult(converterPreference.converter.convert(quantity, status),
+            return RouteResult(converterPreference.converter.convert(quantity, rounder, status),
                                converterPreference.precision,
                                converterPreference.targetUnit.copy(status));
         }
@@ -113,7 +113,7 @@ RouteResult UnitsRouter::route(double quantity, UErrorCode &status) const {
 
     // In case of the `quantity` does not fit in any converter limit, use the last converter.
     const auto &lastConverterPreference = (*converterPreferences_[converterPreferences_.length() - 1]);
-    return RouteResult(lastConverterPreference.converter.convert(quantity, status),
+    return RouteResult(lastConverterPreference.converter.convert(quantity, rounder, status),
                        lastConverterPreference.precision,
                        lastConverterPreference.targetUnit.copy(status));
 }

--- a/icu4c/source/i18n/units_router.h
+++ b/icu4c/source/i18n/units_router.h
@@ -128,7 +128,10 @@ class U_I18N_API UnitsRouter {
   public:
     UnitsRouter(MeasureUnit inputUnit, StringPiece locale, StringPiece usage, UErrorCode &status);
 
-    RouteResult route(double quantity, UErrorCode &status) const;
+    RouteResult route(double quantity, UErrorCode &status) const {
+        return route(quantity, nullptr, status);
+    }
+    RouteResult route(double quantity, icu::number::impl::RoundingImpl *rounder, UErrorCode &status) const;
 
     /**
      * Returns the list of possible output units, i.e. the full set of

--- a/icu4c/source/i18n/units_router.h
+++ b/icu4c/source/i18n/units_router.h
@@ -21,6 +21,9 @@ U_NAMESPACE_BEGIN
 
 // Forward declarations
 class Measure;
+namespace number {
+class Precision;
+}
 
 namespace units {
 
@@ -143,6 +146,9 @@ class U_I18N_API UnitsRouter {
     MaybeStackVector<MeasureUnit> outputUnits_;
 
     MaybeStackVector<ConverterPreference> converterPreferences_;
+
+    static number::Precision parseSkeletonToPrecision(icu::UnicodeString precisionSkeleton,
+                                                      UErrorCode &status);
 };
 
 } // namespace units

--- a/icu4c/source/i18n/units_router.h
+++ b/icu4c/source/i18n/units_router.h
@@ -34,21 +34,13 @@ struct RouteResult : UMemory {
     // TODO(icu-units/icu#21): figure out the right mixed unit API.
     MaybeStackVector<Measure> measures;
 
-    // A skeleton string starting with a precision-increment.
-    //
-    // TODO(hugovdm): generalise? or narrow down to only a precision-increment?
-    // or document that other skeleton elements are ignored?
-    //
-    // UPDATE/TODO: This can be deleted, it's moved into UnitsRouter!
-    UnicodeString precision;
-
     // The output unit for this RouteResult. This may be a MIXED unit - for
     // example: "yard-and-foot-and-inch", for which `measures` will have three
     // elements.
     MeasureUnitImpl outputUnit;
 
-    RouteResult(MaybeStackVector<Measure> measures, UnicodeString precision, MeasureUnitImpl outputUnit)
-        : measures(std::move(measures)), precision(std::move(precision)), outputUnit(std::move(outputUnit)) {}
+    RouteResult(MaybeStackVector<Measure> measures, MeasureUnitImpl outputUnit)
+        : measures(std::move(measures)), outputUnit(std::move(outputUnit)) {}
 };
 
 /**

--- a/icu4c/source/i18n/units_router.h
+++ b/icu4c/source/i18n/units_router.h
@@ -38,6 +38,8 @@ struct RouteResult : UMemory {
     //
     // TODO(hugovdm): generalise? or narrow down to only a precision-increment?
     // or document that other skeleton elements are ignored?
+    //
+    // UPDATE/TODO: This can be deleted, it's moved into UnitsRouter!
     UnicodeString precision;
 
     // The output unit for this RouteResult. This may be a MIXED unit - for
@@ -131,6 +133,16 @@ class U_I18N_API UnitsRouter {
     RouteResult route(double quantity, UErrorCode &status) const {
         return route(quantity, nullptr, status);
     }
+
+    /**
+     * Performs locale and usage sensitive unit conversion.
+     * @param quantity The quantity to convert, expressed in terms of inputUnit.
+     * @param rounder If not null, this RoundingImpl will be used to do rounding
+     *     on the converted value. If the rounder lacks an fPrecision, the
+     *     rounder will be modified to use the preferred precision for the usage
+     *     and locale preference, alternatively with the default precision.
+     * @param status Receives status.
+     */
     RouteResult route(double quantity, icu::number::impl::RoundingImpl *rounder, UErrorCode &status) const;
 
     /**

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -1110,7 +1110,7 @@ group: unitsformatter
     units_data.o units_converter.o units_complexconverter.o units_router.o
   deps
     resourcebundle units_extra double_conversion number_representation formattable sort
-#    number_rounding? FIXME
+    number_rounding  # Seems to work! No dependency trouble for this approach? FIXME
 
 group: decnumber
     decContext.o decNumber.o

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -1110,7 +1110,7 @@ group: unitsformatter
     units_data.o units_converter.o units_complexconverter.o units_router.o
   deps
     resourcebundle units_extra double_conversion number_representation formattable sort
-    number_rounding  # Seems to work! No dependency trouble for this approach? FIXME
+    number_rounding
 
 group: decnumber
     decContext.o decNumber.o

--- a/icu4c/source/test/depstest/dependencies.txt
+++ b/icu4c/source/test/depstest/dependencies.txt
@@ -1110,6 +1110,7 @@ group: unitsformatter
     units_data.o units_converter.o units_complexconverter.o units_router.o
   deps
     resourcebundle units_extra double_conversion number_representation formattable sort
+#    number_rounding? FIXME
 
 group: decnumber
     decContext.o decNumber.o

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -753,11 +753,8 @@ void NumberFormatterApiTest::unitMeasure() {
             4.28571,
             u"4 metric tons, 285 kilograms, 710 grams");
 
-    // TODO(icu-units#73): deal with this "1 foot 12 inches" problem.
-    // At the time of writing, this test would pass, but is commented out
-    // because it reflects undesired behaviour:
     assertFormatSingle(
-            u"Demonstrating the \"1 foot 12 inches\" problem",
+            u"Testing  \"1 foot 12 inches\"",
             nullptr,
             u"unit/foot-and-inch",
             NumberFormatter::with()
@@ -766,8 +763,7 @@ void NumberFormatterApiTest::unitMeasure() {
                 .unitWidth(UNUM_UNIT_WIDTH_FULL_NAME),
             Locale("en-US"),
             1.9999,
-            // This is undesireable but current behaviour:
-            u"1 foot, 12 inches");
+            u"2 feet, 0 inches");
 }
 
 void NumberFormatterApiTest::unitCompoundMeasure() {

--- a/icu4c/source/test/intltest/numbertest_api.cpp
+++ b/icu4c/source/test/intltest/numbertest_api.cpp
@@ -753,21 +753,21 @@ void NumberFormatterApiTest::unitMeasure() {
             4.28571,
             u"4 metric tons, 285 kilograms, 710 grams");
 
-//     // TODO(icu-units#73): deal with this "1 foot 12 inches" problem.
-//     // At the time of writing, this test would pass, but is commented out
-//     // because it reflects undesired behaviour:
-//     assertFormatSingle(
-//             u"Demonstrating the \"1 foot 12 inches\" problem",
-//             nullptr,
-//             u"unit/foot-and-inch",
-//             NumberFormatter::with()
-//                 .unit(MeasureUnit::forIdentifier("foot-and-inch", status))
-//                 .precision(Precision::maxSignificantDigits(4))
-//                 .unitWidth(UNUM_UNIT_WIDTH_FULL_NAME),
-//             Locale("en-US"),
-//             1.9999,
-//             // This is undesireable but current behaviour:
-//             u"1 foot, 12 inches");
+    // TODO(icu-units#73): deal with this "1 foot 12 inches" problem.
+    // At the time of writing, this test would pass, but is commented out
+    // because it reflects undesired behaviour:
+    assertFormatSingle(
+            u"Demonstrating the \"1 foot 12 inches\" problem",
+            nullptr,
+            u"unit/foot-and-inch",
+            NumberFormatter::with()
+                .unit(MeasureUnit::forIdentifier("foot-and-inch", status))
+                .precision(Precision::maxSignificantDigits(4))
+                .unitWidth(UNUM_UNIT_WIDTH_FULL_NAME),
+            Locale("en-US"),
+            1.9999,
+            // This is undesireable but current behaviour:
+            u"1 foot, 12 inches");
 }
 
 void NumberFormatterApiTest::unitCompoundMeasure() {

--- a/icu4c/source/test/intltest/units_test.cpp
+++ b/icu4c/source/test/intltest/units_test.cpp
@@ -408,6 +408,10 @@ void unitsTestDataLineFn(void *context, char *fields[][2], int32_t fieldCount, U
     msg.clear();
     msg.append("Converting 1000 ", status).append(x, status).append(" to ", status).append(y, status);
     unitsTest->assertEqualsNear(msg.data(), expected, got, 0.0001 * expected);
+    double inverted = converter.convertInverse(got);
+    msg.clear();
+    msg.append("Converting back to ", status).append(x, status).append(" from ", status).append(y, status);
+    unitsTest->assertEqualsNear(msg.data(), 1000, inverted, 0.0001);
 }
 
 /**
@@ -439,7 +443,7 @@ void UnitsTest::testConversions() {
 }
 
 void UnitsTest::testComplexUnitsConverter() {
-    IcuTestErrorCode status(*this, "UnitsTest::testComplexUnitConversions");
+    IcuTestErrorCode status(*this, "UnitsTest::testComplexUnitsConverter");
     ConversionRates rates(status);
     MeasureUnit input = MeasureUnit::getFoot();
     MeasureUnit output = MeasureUnit::forIdentifier("foot-and-inch", status);


### PR DESCRIPTION
This currently triggers a segfault, which is likely worth hunting in its own right, since I don't think this code created it:

```
SUMMARY: AddressSanitizer: SEGV /home/hugovdm/git/icu2/icu4c/source/i18n/./unicode/measure.h in icu_68::Measure::getUnit() const
```

The purpose of this proof-of-concept is to propose and test a reasonable fix for https://github.com/icu-units/icu/issues/73 - it seems we do not have a dependencies.txt problem, so this solution seems viable.

<!--
Thank you for your pull request.
Please see http://site.icu-project.org/processes/contribute for general
information on contributing to ICU.

You will be automatically asked to sign the contributors license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/icu
- license: http://www.unicode.org/copyright.html#License
-->

##### Checklist

- [ ] Issue filed: https://unicode-org.atlassian.net/browse/ICU-_____
- [ ] Updated PR title and link in previous line to include Issue number
- [ ] Issue accepted
- [ ] Tests included
- [ ] Documentation is changed or added

